### PR TITLE
go and python version added

### DIFF
--- a/req.py
+++ b/req.py
@@ -1,0 +1,47 @@
+import requests
+from urllib.parse import quote
+import idna
+import unicodedata
+
+def fuzz_unicode():
+    for code_point in range(1, 0x10FFFF + 1):
+        # Skip invalid UTF-16 surrogate ranges
+        if 0xD800 <= code_point <= 0xDFFF:
+            continue
+
+        try:
+            # Convert Unicode code point to character
+            fuzz_char = chr(code_point)
+
+            # Skip control characters and other invalid characters
+            if unicodedata.category(fuzz_char).startswith('C'):
+                continue
+
+            # Encode the Unicode character for use in URL
+            encoded_char = quote(fuzz_char)
+
+            # Use Unicode character in a GET parameter instead of IP
+            domain = f"{encoded_char}27.0.0.1"
+            try:
+                # Encode domain using IDNA
+                encoded_domain = idna.encode(domain).decode('ascii')
+            except idna.IDNAError:
+                # Skip if domain cannot be encoded
+                continue
+
+            url = f"http://{encoded_domain}/"
+
+            # Send HTTP GET request
+            response = requests.get(url, timeout=2)
+
+            # Check response
+            if "ok" in response.text:
+                print(f"Unicode Character: {fuzz_char} (U+{code_point:04X}) | status code: {response.status_code}")
+
+        except requests.exceptions.RequestException as e:
+            # Handle errors (e.g., network failures, encoding issues)
+            # print(f"Error processing Unicode (U+{code_point:04X}): {e}")
+            pass
+
+# Run the fuzzing function
+fuzz_unicode()

--- a/test.go
+++ b/test.go
@@ -1,0 +1,54 @@
+package main
+
+import (
+        "bytes"
+        "fmt"
+        "io/ioutil"
+        "net/http"
+        "unicode/utf8"
+)
+
+func fuzzUnicode() {
+        for codePoint := 1; codePoint <= 0x10FFFF; codePoint++ {
+                // Skip invalid UTF-16 surrogate ranges
+                if codePoint >= 0xD800 && codePoint <= 0xDFFF {
+                        continue
+                }
+
+                // Convert Unicode code point to character
+                fuzzChar := string(rune(codePoint))
+
+                // Use Unicode character in a GET parameter instead of IP
+        //  Note: It's HIGHLY unusual to put unicode characters directly into an IP address.  
+        //        This code assumes you have a local server setup to handle this.
+                url := fmt.Sprintf("http://%s27.0.0.1/", fuzzChar)
+
+                // Make HTTP GET request
+                response, err := http.Get(url)
+                if err != nil {
+                        // Handle errors properly, but don't print every error if you get lots
+            //      It's likely many unicode points will cause errors.
+                        // fmt.Printf("Error processing Unicode (U+%04X): %v\n", codePoint, err)  // Commented out to reduce output
+                        continue
+                }
+                defer response.Body.Close()
+
+                // Read response body
+                body, err := ioutil.ReadAll(response.Body)
+                if err != nil {
+            //      Same as above, likely many errors here.
+                        // fmt.Printf("Error reading response body for Unicode (U+%04X): %v\n", codePoint, err) // Commented out
+                        continue
+                }
+
+                // Check response.  Only print if BOTH are true.
+                if utf8.Valid(body) && bytes.Contains(body, []byte("ok")) {
+                        fmt.Printf("Valid Unicode Character: %s (U+%04X) - Response: %s\n", fuzzChar, codePoint, body)
+                }
+        }
+}
+
+func main() {
+        // Run the fuzzing function
+        fuzzUnicode()
+}


### PR DESCRIPTION
same concept in python and go.
python version: It filters out control characters and uses IDNA encoding to handle Unicode characters in domain names.

go version: nothing special, uses go standard libs net/http and unicode/utf8